### PR TITLE
upgrade from 4.0 to 4.3

### DIFF
--- a/active_ap/main/main.cc
+++ b/active_ap/main/main.cc
@@ -112,7 +112,11 @@ void softap_init() {
     }
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
-    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config));
+    //ESP_IF_WIFI_AP works for esp-idf 4.0
+    //ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config));
+    //https://github.com/StevenMHernandez/ESP32-CSI-Tool/issues/37
+    //WIFI_IF_AP works for esp-idf 4.3
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_config));
     ESP_ERROR_CHECK(esp_wifi_start());
 
     esp_wifi_set_ps(WIFI_PS_NONE);

--- a/active_sta/main/main.cc
+++ b/active_sta/main/main.cc
@@ -145,7 +145,11 @@ void station_init() {
     strlcpy((char *) wifi_config.sta.password, ESP_WIFI_PASS, sizeof(ESP_WIFI_PASS));
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    //ESP_IF_WIFI_STA works for esp-idf 4.0
+    //ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    //https://github.com/StevenMHernandez/ESP32-CSI-Tool/issues/37
+    //WIFI_IF_STA works for esp-idf 4.3
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
     ESP_ERROR_CHECK(esp_wifi_start());
 
     esp_wifi_set_ps(WIFI_PS_NONE);


### PR DESCRIPTION
this change is to address the issue: https://github.com/StevenMHernandez/ESP32-CSI-Tool/issues/37

- [x] upgrade from 4.0 to 4.3

`active_ap` and `active_sta` need a change to support 4.3. `passive` doesn't need.

Validation:
1) complied on Mac
2) flashed to 3 ESP32
3) 3 ESP32 (one AP, one STA, one passive) work as expected.
