### PR TITLE
Improve rate consistency of CSI data collection

### DIFF
--- a/_components/sockets_component.h
+++ b/_components/sockets_component.h
@@ -59,14 +59,10 @@ void socket_transmitter_sta_loop(bool (*is_wifi_connected)()) {
                 continue;
             }
 
-#ifdef CONFIG_PACKET_RATE
-            if(CONFIG_PACKET_RATE > 0) {
-                double wait_duration = (1000.0 / CONFIG_PACKET_RATE) - lag;
-                int w = floor(wait_duration);
-                vTaskDelay(w);
-                // ets_delay_us((wait_duration - w) * 1000);
-            } else
-                vTaskDelay(10);
+#if defined CONFIG_PACKET_RATE && (CONFIG_PACKET_RATE > 0)
+            double wait_duration = (1000.0 / CONFIG_PACKET_RATE) - lag;
+            int w = floor(wait_duration);
+            vTaskDelay(w);
 #else
             vTaskDelay(10); // This limits TX to approximately 100 per second.
 #endif


### PR DESCRIPTION
The changes in this pull request measure the lag created by functions such as `sendto()` to send CSI data over the serial connection. This lag is then negated from the programmed delay (using `vTaskDelay()`) to maintain a consistent CSI data rate as specified in the `active_sta` app's data rate field (in Hz).