### PR TITLE
Update README for v4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ The following configurations are important for this project:
 
 1. `Serial flasher config > 'idf.py monitor' baud rate > Custom Baud Rate`
 2. `Serial flasher config > Custom baud rate value > 921600` This allows more data to be transmitted on the Serial port
-3. `Component config > Common ESP32-related > Channel for console output > Custom UART`
+3. `Component config > Common ESP32-related > Channel for console output > Custom UART` <br/>
    For v4.4, this is `Component config > ESP System Settings > Channel for console output > Custom UART`
-5. `Component config > Common ESP32-related > UART console baud rate > 921600`
+5. `Component config > Common ESP32-related > UART console baud rate > 921600` <br/>
    For v4.4, this is `Component config > ESP System Settings > UART console baud rate > 921600`
 7. `Component config > Wi-Fi > WiFi CSI(Channel State Information)` (Press space to select)
 8. `Component config > FreeRTOS > Tick rate (Hz) > 1000`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In addition to these ESP32 specific projects, we also consider methods for analy
 ## Installation
 
 First, Install Espressif IoT Development Framework (ESP-IDF) by following their [step by step installation guide](https://docs.espressif.com/projects/esp-idf/en/release-v4.3/esp32/get-started/index.html).
-Notice, this project requires **version (v4.3) of ESP-IDF**.  
+Notice, this project requires **version (v4.3) of ESP-IDF**. It is also compatible with v4.4.
 
 **Important:** It is important that you are able to successfully build and flash the example project from the esp-idf guide onto your own esp32.
 If you have issues building the example project on your hardware, **do not create an issue in this github repo**.
@@ -63,10 +63,12 @@ The following configurations are important for this project:
 1. `Serial flasher config > 'idf.py monitor' baud rate > Custom Baud Rate`
 2. `Serial flasher config > Custom baud rate value > 921600` This allows more data to be transmitted on the Serial port
 3. `Component config > Common ESP32-related > Channel for console output > Custom UART`
-4. `Component config > Common ESP32-related > UART console baud rate > 921600`
-5. `Component config > Wi-Fi > WiFi CSI(Channel State Information)` (Press space to select)
-6. `Component config > FreeRTOS > Tick rate (Hz) > 1000`
-7. `ESP32 CSI Tool Config > ****` all options in this menu can be specified per your experiment requirements.
+   For v4.4, this is `Component config > ESP System Settings > Channel for console output > Custom UART`
+5. `Component config > Common ESP32-related > UART console baud rate > 921600`
+   For v4.4, this is `Component config > ESP System Settings > UART console baud rate > 921600`
+7. `Component config > Wi-Fi > WiFi CSI(Channel State Information)` (Press space to select)
+8. `Component config > FreeRTOS > Tick rate (Hz) > 1000`
+9. `ESP32 CSI Tool Config > ****` all options in this menu can be specified per your experiment requirements.
 
 **NOTE:** For some systems, other baud rates may be required. Good options to try are `921600`, `1000000`, `1152000`, `1500000`, and `1552000`.  
 **The higher baud rate the better! Baud rate is extremely important to achieve high sampling rates without lag!**  


### PR DESCRIPTION
Following the steps in the README still works with ESP-IDF v4.4. Two setting locations are slightly changed, which is now documented for v4.4